### PR TITLE
Implement Phosphobot demo stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# aloha-lite
+# Aloha Lite
+
+This repository provides a minimal web stack for controlling Phosphobot to dispense fluids and capture snapshots when the robot reaches a target pose. The stack is composed of FastAPI services for robot control and vision capture, served behind a Traefik gateway together with a very small front-end.
+
+## Running locally
+
+```bash
+docker-compose up --build -d
+```
+
+Once started you can access:
+
+- `http://localhost:8080/` – web front-end
+- `http://localhost:9000/docs` – Robot Service Swagger UI
+- `http://localhost:9001/metrics` – Prometheus metrics
+
+Create the `snapshots` bucket in object storage after the services start:
+
+```bash
+docker exec -it $(docker compose ps -q vision-bridge) \
+  aws --endpoint-url http://minio:9000 s3 mb s3://snapshots
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.8"
+services:
+  api-gateway:
+    image: traefik:v3.0
+    command:
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:8080"
+    ports: ["8080:8080"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  robot-service:
+    build: ./robot_service
+    environment:
+      - PHOS_URL=http://phosphobot
+      - MODEL_ID=phospho-app/so101_dispense_v1-groot
+      - TARGET_POSE=[0.0,1.57,0.0,-1.57,0.0,1.57]
+      - TOL=0.03
+    labels:
+      - "traefik.http.routers.robot.rule=PathPrefix(`/robot`)"
+      - "traefik.http.routers.robot.entrypoints=web"
+    depends_on: [api-gateway]
+
+  vision-bridge:
+    build: ./vision_bridge
+    environment:
+      - PHOS_URL=http://phosphobot
+      - S3_ENDPOINT=http://minio:9000
+      - AWS_ACCESS_KEY_ID=miniokey
+      - AWS_SECRET_ACCESS_KEY=miniosecret
+      - BUCKET=snapshots
+    depends_on: [robot-service]
+
+  frontend:
+    build: ./frontend
+    labels:
+      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.frontend.entrypoints=web"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><html><meta charset="utf-8">
+<title>Colour-Mix Console</title>
+<style>
+body{font-family:Arial,Helvetica,sans-serif;margin:2rem;max-width:480px}
+label,button{display:block;margin-top:1rem}
+img{max-width:100%}
+</style>
+<h1>Dispense + Snapshot Demo</h1>
+
+<label>Colour
+  <select id="colour"><option>blue</option><option>red</option><option>green</option></select>
+</label>
+<label>Volume\u00a0(ml)
+  <input id="vol" type="number" min="1" max="50" value="25">
+</label>
+<button onclick="send()">Dispense & Snap</button>
+<pre id="log"></pre>
+<img id="snap">
+
+<script>
+async function sleep(ms){return new Promise(r=>setTimeout(r,ms))}
+async function send(){
+  const colour=document.querySelector('#colour').value
+  const vol=document.querySelector('#vol').value
+  const body={mix_id:1,run_id:1,colour,volume_ml:vol}
+  log('POST /robot/dispense '+JSON.stringify(body))
+
+  let r=await fetch('/robot/dispense',{method:'POST',
+          headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
+  let {cmd_id}=await r.json()
+  log('cmd_id='+cmd_id)
+
+  // poll status every second
+  while(true){
+    await sleep(1000)
+    let s=await (await fetch('/robot/'+cmd_id+'/status')).json()
+    log('status='+JSON.stringify(s))
+    if(s.status!=='running')break
+  }
+  // fetch snapshot
+  let snap=await (await fetch('/robot/'+cmd_id+'/pose-snapshot')).json()
+  document.querySelector('#snap').src=snap.url
+}
+function log(txt){document.querySelector('#log').textContent+=txt+"\n"}
+</script>
+

--- a/robot_service/Dockerfile
+++ b/robot_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/robot_service/main.py
+++ b/robot_service/main.py
@@ -1,0 +1,103 @@
+import os, json, asyncio, uuid
+from typing import List
+
+import httpx, zmq, zmq.asyncio
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from prometheus_client import Counter, Histogram, start_http_server
+
+PHOS_URL   = os.getenv("PHOS_URL", "http://phosphobot")
+MODEL_ID   = os.getenv("MODEL_ID")
+TARGET_POSE = json.loads(os.getenv("TARGET_POSE", "[0,0,0,0,0,0]"))
+TOL        = float(os.getenv("TOL", "0.03"))
+
+REQS_TOTAL = Counter("robot_requests_total", "Robot dispense requests")
+REQ_LAT    = Histogram("robot_request_latency_seconds", "Robot latency")
+
+# --- FastAPI -----------------------------------------------------------------
+app = FastAPI(title="Robot Service", version="0.1")
+
+class DispenseRequest(BaseModel):
+    mix_id: int
+    run_id: int
+    colour: str = Field(pattern="^(red|green|blue)$")
+    volume_ml: float = Field(gt=0.0, le=50.0)
+
+class DispenseStatus(BaseModel):
+    status: str
+    predicted_squeeze_sec: float | None = None
+
+# in-memory store; replace w/ DB table in prod
+TASKS: dict[str, DispenseStatus] = {}
+
+
+def pose_close(q: List[float]) -> bool:
+    return all(abs(a-b) < TOL for a, b in zip(q, TARGET_POSE))
+
+
+async def zmq_state_listener():
+    ctx = zmq.asyncio.Context.instance()
+    sub = ctx.socket(zmq.SUB)
+    sub.connect("tcp://phosphobot:5555")   # state topic
+    sub.setsockopt_string(zmq.SUBSCRIBE, "state")
+    while True:
+        _topic, raw = await sub.recv_multipart()
+        msg = json.loads(raw)
+        if pose_close(msg["joints"]):
+            # broadcast event to any waiting CSR tasks
+            for fut in list(POSE_WAITERS):
+                if not fut.done():
+                    fut.set_result(msg)
+        for tid, st in TASKS.items():
+            if st.status == "running" and msg.get("status") == "success":
+                st.status = "success"
+        await asyncio.sleep(0.0)
+
+POSE_WAITERS: set[asyncio.Future] = set()
+asyncio.create_task(zmq_state_listener())
+start_http_server(9001)     # Prometheus
+
+# --------------------------------------------------------------------------- #
+@app.post("/robot/dispense")
+@REQ_LAT.time()
+async def dispense(req: DispenseRequest):
+    REQS_TOTAL.inc()
+    tid = str(uuid.uuid4())
+    prompt = f"Dispense {req.volume_ml} ml from the {req.colour} bottle"
+    TASKS[tid] = DispenseStatus(status="running")
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        phos_resp = await client.post(f"{PHOS_URL}/inference",
+                                      json={"model": MODEL_ID, "prompt": prompt})
+        if phos_resp.status_code != 200:
+            raise HTTPException(502, "Phosphobot error")
+
+        squeeze = phos_resp.json().get("predicted_squeeze_sec")
+        TASKS[tid].predicted_squeeze_sec = squeeze
+
+    return {"cmd_id": tid, **TASKS[tid].model_dump()}
+
+
+@app.get("/robot/{cmd_id}/status")
+async def status(cmd_id: str):
+    st = TASKS.get(cmd_id)
+    if not st:
+        raise HTTPException(404)
+    return st.model_dump()
+
+
+@app.get("/robot/{cmd_id}/pose-snapshot")
+async def pose_snapshot(cmd_id: str, cam: str = "top_cam"):
+    """
+    Blocks until pose reached, then returns a presigned S3 URL provided
+    by Vision-Bridge (polls kv-store every 100 ms).
+    """
+    fut = asyncio.get_event_loop().create_future()
+    POSE_WAITERS.add(fut)
+    await fut            # wait until pose reached
+
+    # ask Vision-Bridge to capture
+    async with httpx.AsyncClient(timeout=30.0) as cl:
+        vb = await cl.post("http://vision-bridge:9002/snapshot",
+                           json={"cmd_id": cmd_id, "cam_id": cam})
+        return vb.json()

--- a/robot_service/requirements.txt
+++ b/robot_service/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.* 
+uvicorn[standard]==0.29.* 
+pydantic==2.* 
+httpx==0.27.* 
+aiokafka==0.9.*        # optional if you switch to Kafka events
+pyzmq==26.*            # ZMQ subscribe (Phosphobot state bus)
+prometheus-client==0.20.*

--- a/vision_bridge/Dockerfile
+++ b/vision_bridge/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9002"]

--- a/vision_bridge/main.py
+++ b/vision_bridge/main.py
@@ -1,0 +1,42 @@
+import os, uuid, io, datetime
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import httpx, boto3
+from prometheus_client import Counter, start_http_server
+
+PHOS_URL = os.getenv("PHOS_URL", "http://phosphobot")
+BUCKET   = os.getenv("BUCKET", "snapshots")
+s3 = boto3.client("s3",
+        endpoint_url=os.getenv("S3_ENDPOINT"),
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
+
+SNAP_OK  = Counter("cam_snapshot_ok_total", "Snapshots succeeded")
+SNAP_ERR = Counter("cam_snapshot_err_total", "Snapshots failed")
+start_http_server(9003)
+
+# ------------------------- FastAPI ----------------------------------------
+app = FastAPI(title="Vision-Bridge")
+
+class SnapReq(BaseModel):
+    cmd_id: str
+    cam_id: str = "top_cam"
+
+@app.post("/snapshot")
+async def snapshot(req: SnapReq):
+    ts   = datetime.datetime.utcnow().isoformat(timespec="seconds")
+    key  = f"{req.cmd_id}/{req.cam_id}_{ts}.jpg"
+    url  = f"{PHOS_URL}/camera/snapshot/{req.cam_id}?format=jpeg"
+
+    async with httpx.AsyncClient() as cl:
+        r = await cl.get(url, timeout=10.0)
+        if r.status_code != 200:
+            SNAP_ERR.inc()
+            raise HTTPException(502, "Camera error")
+        data = io.BytesIO(r.content)
+        s3.upload_fileobj(data, BUCKET, key,
+                          ExtraArgs={"ContentType": "image/jpeg"})
+    SNAP_OK.inc()
+    presigned = s3.generate_presigned_url("get_object",
+        Params={"Bucket": BUCKET, "Key": key}, ExpiresIn=86400)
+    return {"url": presigned}

--- a/vision_bridge/requirements.txt
+++ b/vision_bridge/requirements.txt
@@ -1,0 +1,1 @@
+fastapi uvicorn[standard] httpx boto3 python-multipart prometheus-client


### PR DESCRIPTION
## Summary
- set up docker-compose for Traefik gateway, robot service, vision bridge and frontend
- implement FastAPI robot service with pose monitoring and Prometheus metrics
- implement vision bridge service to capture snapshots and upload to S3
- provide tiny static frontend served by nginx
- update README with usage instructions

## Testing
- `python -m py_compile robot_service/main.py vision_bridge/main.py`
- `docker-compose config -q` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686631527b0883328c77b21bb8ffda99