### PR TITLE
Add color checker detection API

### DIFF
--- a/vision_bridge/requirements.txt
+++ b/vision_bridge/requirements.txt
@@ -1,1 +1,2 @@
 fastapi uvicorn[standard] httpx boto3 python-multipart prometheus-client
+colour-checker-detection


### PR DESCRIPTION
## Summary
- integrate colour-checker-detection library
- add `/color-checker` endpoint in Vision Bridge to find colour checkers in uploaded images
- install colour-checker-detection dependency

## Testing
- `pip check`
- `python -m py_compile vision_bridge/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6866394199a883329a1eee31529e2452