### PR TITLE
Add additional FastAPI endpoint tests

### DIFF
--- a/tests/test_robot_service.py
+++ b/tests/test_robot_service.py
@@ -1,0 +1,67 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import asyncio
+import importlib
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# Utility to import module with patched environment
+
+def load_robot_module():
+    def fake_create_task(coro):
+        coro.close()
+        loop = asyncio.new_event_loop()
+        return loop.create_future()
+
+    with patch('asyncio.create_task', fake_create_task), \
+         patch('prometheus_client.start_http_server', lambda *a, **k: None), \
+         patch('prometheus_client.Histogram.time', lambda self: (lambda f: f)):
+        return importlib.import_module('robot_service.main')
+
+
+@pytest.fixture
+def robot_app():
+    mod = load_robot_module()
+    return mod
+
+
+def test_pose_close_match(robot_app):
+    robot_app.TARGET_POSE = [0.0, 0.0]
+    robot_app.TOL = 0.1
+    assert robot_app.pose_close([0.05, 0.05])
+    assert not robot_app.pose_close([0.2, 0.0])
+
+
+def test_dispense_and_status(robot_app):
+    class DummyResponse:
+        def __init__(self):
+            self.status_code = 200
+        def json(self):
+            return {'predicted_squeeze_sec': 1.23}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, json):
+            return DummyResponse()
+
+    with patch.object(robot_app.httpx, 'AsyncClient', lambda *a, **k: DummyClient()), \
+         patch.object(robot_app.uuid, 'uuid4', lambda: 'abc'):
+        client = TestClient(robot_app.app)
+        payload = {'mix_id': 1, 'run_id': 2, 'colour': 'red', 'volume_ml': 10.0}
+        resp = client.post('/robot/dispense', json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['cmd_id'] == 'abc'
+        assert data['predicted_squeeze_sec'] == 1.23
+
+        status = client.get(f"/robot/{data['cmd_id']}/status")
+        assert status.status_code == 200
+        assert status.json()['status'] == 'running'
+        assert status.json()['predicted_squeeze_sec'] == 1.23

--- a/tests/test_vision_bridge.py
+++ b/tests/test_vision_bridge.py
@@ -1,0 +1,55 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import io
+import importlib
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+
+def load_vb_module():
+    with patch('prometheus_client.start_http_server', lambda *a, **k: None):
+        return importlib.import_module('vision_bridge.main')
+
+
+@pytest.fixture
+def vb_app():
+    return load_vb_module()
+
+
+def test_color_checker_invalid_image(vb_app):
+    client = TestClient(vb_app.app)
+    response = client.post('/color-checker', files={'file': ('bad.txt', b'invalid', 'text/plain')})
+    assert response.status_code == 400
+
+
+def test_snapshot_upload(vb_app):
+    class DummyResponse:
+        def __init__(self):
+            self.status_code = 200
+            self.content = b'jpgdata'
+        def json(self):
+            return {}
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, url, timeout):
+            return DummyResponse()
+    class DummyS3:
+        def upload_fileobj(self, data, bucket, key, ExtraArgs=None):
+            assert bucket == vb_app.BUCKET
+        def generate_presigned_url(self, *a, **k):
+            return 'http://example.com'
+    with patch.object(vb_app, 'httpx', vb_app.httpx), \
+         patch.object(vb_app.httpx, 'AsyncClient', lambda *a, **k: DummyClient()), \
+         patch.object(vb_app, 's3', DummyS3()):
+        client = TestClient(vb_app.app)
+        payload = {'cmd_id': '1', 'cam_id': 'c'}
+        resp = client.post('/snapshot', json=payload)
+        assert resp.status_code == 200
+        assert resp.json()['url'] == 'http://example.com'

--- a/vision_bridge/tests/test_color_checker.py
+++ b/vision_bridge/tests/test_color_checker.py
@@ -1,8 +1,21 @@
-from fastapi.testclient import TestClient
-from vision_bridge.main import app
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-if __name__ == "__main__":
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import importlib
+
+
+def load_app():
+    with patch('prometheus_client.start_http_server', lambda *a, **k: None):
+        mod = importlib.import_module('vision_bridge.main')
+    return mod.app
+
+
+def test_color_checker_sample():
+    app = load_app()
     client = TestClient(app)
-    with open("vision_bridge/samples/ColorCheckerClassic_24patch_sRGB.png", "rb") as f:
-        response = client.post("/color-checker", files={"file": ("image.png", f, "image/png")})
-    print(response.json())
+    with open('vision_bridge/samples/ColorCheckerClassic_24patch_sRGB.png', 'rb') as f:
+        resp = client.post('/color-checker', files={'file': ('img.png', f, 'image/png')})
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- create pytest modules for robot service and vision bridge
- update existing color checker test to use pytest
- ensure imports work without installing services by patching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bd4f38088332a957ee695dbcd15b