### PR TITLE
Fix dispense endpoint serialization error

### DIFF
--- a/robot_service/main.py
+++ b/robot_service/main.py
@@ -528,9 +528,13 @@ async def execute_multi_color_dispensing_task(cmd_id: str, color_ratios: ColorRa
 
 # --------------------------------------------------------------------------- #
 @app.post("/robot/dispense")
-@REQ_LAT.time()
 async def dispense(req: DispenseRequest, background_tasks: BackgroundTasks):
+    """Handle dispense requests and start the background procedure."""
     REQS_TOTAL.inc()
+    with REQ_LAT.time():
+        return await _dispense_impl(req, background_tasks)
+
+async def _dispense_impl(req: DispenseRequest, background_tasks: BackgroundTasks):
     logger.info(f"Received dispense request: {req}")
     logger.info(f"color_ratios: {req.color_ratios}")
     logger.info(f"normalized_percentages: {req.normalized_percentages}")


### PR DESCRIPTION
## Summary
- avoid using synchronous timing decorator on async endpoint
- wrap handler body in REQ_LAT.time() context
- move previous logic to internal `_dispense_impl`

## Testing
- `python -m py_compile robot_service/main.py`
- `python - <<'PY'
import requests
url='http://127.0.0.1:8000/robot/dispense'
body={"mix_id":1,"run_id":1,"colour":"red","color_ratios":{"red":1,"yellow":1,"blue":1},"normalized_percentages":{"red":33.33,"yellow":33.33,"blue":33.33}}
resp=requests.post(url,json=body)
print(resp.status_code)
print(resp.json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6880ababbe1c8332b86c7388616cdc5c