### PR TITLE
Add MCP server for Claude control

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ aloha-lite/
 │   ├── trajectory_executor.py  # Advanced trajectory execution
 │   └── joint_reader_examples.py # Joint reading examples
 ├── frontend/              # Web interface and service proxy (FastAPI port 3000)
+├── mcp_server/                # MCP control server for Anthropic Claude desktop
 ├── vision_bridge/         # Image processing service (FastAPI port 5000)
 ├── phosphobot/           # Robot control system (git subtree)
 ├── aloha-lite-demo2rule/ # Dataset processing tools
@@ -368,6 +369,7 @@ Once started you can access:
 - `http://localhost:8080/` – web front-end for robot operations
 - `http://localhost:8080/robot/docs` – Robot Service Swagger UI  
 - `http://localhost:9001/` – MinIO Console
+- `http://localhost:8080/mcp/health` – MCP server health check
 - Phosphobot dashboard: Manage separately as needed
 - `http://localhost:8080/robot/docs` – Robot Service Swagger UI
 - `http://localhost:9001/metrics` – Robot Service Prometheus metrics
@@ -649,6 +651,7 @@ aloha-lite/
 ├── push_subtree.py               # Automated subtree push (python)
 ├── frontend/                     # Web interface
 ├── robot_service/                # FastAPI robot control
+├── mcp_server/                # MCP control server for Anthropic Claude desktop
 ├── vision_bridge/                # Image processing and computer vision service
 │                                  # - FastAPI service (port 5000) 
 │                                  # - Beaker analysis with AI-powered color detection
@@ -697,6 +700,11 @@ aloha-lite/
 - `GET /status` - Check status of all backend services
 - `POST /robot/*` - Proxy to robot service (eliminates CORS issues)
 - `POST /vision/*` - Proxy to vision service (eliminates CORS issues)
+
+### MCP Server (Port 8900)
+- `GET /health` - MCP server health check
+- `WS  /ws` - WebSocket command channel
+
 
 ### Web Interface Access
 - **Main Interface**: http://localhost:3000 (Primary user interface)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ services:
   api-gateway:
     image: traefik:v3.0
     command:
-      - "--providers.docker=true"
-      - "--entrypoints.web.address=:8080"
-    ports: ["8080:8080"]
+    - --providers.docker=true
+    - --entrypoints.web.address=:8080
+    ports: [8080:8080]
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    - /var/run/docker.sock:/var/run/docker.sock
 
   # phosphobot:
   #   build: ./phosphobot/phosphobot
@@ -28,15 +28,15 @@ services:
     image: minio/minio:latest
     command: server /data --console-address ":9001"
     environment:
-      - MINIO_ROOT_USER=${MINIO_ROOT_USER:-miniokey}
-      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-miniosecret}
+    - MINIO_ROOT_USER=${MINIO_ROOT_USER:-miniokey}
+    - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-miniosecret}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+    - 9000:9000
+    - 9001:9001
     volumes:
-      - minio_data:/data
+    - minio_data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: [CMD, curl, -f, http://localhost:9000/minio/health/live]
       interval: 30s
       timeout: 20s
       retries: 3
@@ -44,15 +44,15 @@ services:
   robot-service:
     build: ./robot_service
     environment:
-      - PHOS_URL=${PHOS_URL:-http://phosphobot}
-      - MODEL_ID=${MODEL_ID:-phospho-app/so101_dispense_v1-groot}
-      - TARGET_POSE=${TARGET_POSE:-[0.0,1.57,0.0,-1.57,0.0,1.57]}
-      - TOL=${TOL:-0.03}
+    - PHOS_URL=${PHOS_URL:-http://phosphobot}
+    - MODEL_ID=${MODEL_ID:-phospho-app/so101_dispense_v1-groot}
+    - TARGET_POSE=${TARGET_POSE:-[0.0,1.57,0.0,-1.57,0.0,1.57]}
+    - TOL=${TOL:-0.03}
     labels:
-      - "traefik.http.routers.robot.rule=PathPrefix(`/robot`)"
-      - "traefik.http.routers.robot.entrypoints=web"
-      - "traefik.http.services.robot.loadbalancer.server.port=8000"
-      - "traefik.enable=true"
+    - traefik.http.routers.robot.rule=PathPrefix(`/robot`)
+    - traefik.http.routers.robot.entrypoints=web
+    - traefik.http.services.robot.loadbalancer.server.port=8000
+    - traefik.enable=true
     depends_on:
       api-gateway:
         condition: service_started
@@ -61,7 +61,7 @@ services:
       minio:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      test: [CMD, curl, -f, http://localhost:8000/docs]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -69,16 +69,16 @@ services:
   vision-bridge:
     build: ./vision_bridge
     environment:
-      - PHOS_URL=${PHOS_URL:-http://phosphobot}
-      - S3_ENDPOINT=${S3_ENDPOINT:-http://minio:9000}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-miniokey}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-miniosecret}
-      - BUCKET=${BUCKET:-snapshots}
+    - PHOS_URL=${PHOS_URL:-http://phosphobot}
+    - S3_ENDPOINT=${S3_ENDPOINT:-http://minio:9000}
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-miniokey}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-miniosecret}
+    - BUCKET=${BUCKET:-snapshots}
     labels:
-      - "traefik.http.routers.vision.rule=PathPrefix(`/vision`)"
-      - "traefik.http.routers.vision.entrypoints=web"
-      - "traefik.http.services.vision.loadbalancer.server.port=8000"
-      - "traefik.enable=true"
+    - traefik.http.routers.vision.rule=PathPrefix(`/vision`)
+    - traefik.http.routers.vision.entrypoints=web
+    - traefik.http.services.vision.loadbalancer.server.port=8000
+    - traefik.enable=true
     depends_on:
       robot-service:
         condition: service_healthy
@@ -87,7 +87,7 @@ services:
       minio:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      test: [CMD, curl, -f, http://localhost:8000/docs]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -95,10 +95,19 @@ services:
   frontend:
     build: ./frontend
     labels:
-      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
-      - "traefik.http.routers.frontend.entrypoints=web"
-      - "traefik.http.services.frontend.loadbalancer.server.port=80"
-      - "traefik.enable=true"
+    - traefik.http.routers.frontend.rule=PathPrefix(`/`)
+    - traefik.http.routers.frontend.entrypoints=web
+    - traefik.http.services.frontend.loadbalancer.server.port=80
+    - traefik.enable=true
 
+  mcp-server:
+    build: ./mcp_server
+    environment:
+    - FRONTEND_URL=http://frontend
+    labels:
+    - traefik.http.routers.mcp.rule=PathPrefix(`/mcp`)
+    - traefik.http.routers.mcp.entrypoints=web
+    - traefik.http.services.mcp.loadbalancer.server.port=8900
+    - traefik.enable=true
 volumes:
   minio_data:

--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py ./
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8900"]

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,0 +1,63 @@
+import os
+import json
+import logging
+import httpx
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://frontend")
+
+app = FastAPI(title="MCP Server", description="Bridge for Anthropic Claude Desktop")
+
+connected_clients = set()
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    connected_clients.add(websocket)
+    await websocket.send_json({"status": "connected"})
+    try:
+        while True:
+            msg = await websocket.receive_text()
+            try:
+                cmd = json.loads(msg)
+            except json.JSONDecodeError:
+                await websocket.send_json({"error": "invalid json"})
+                continue
+            response = await handle_command(cmd)
+            await websocket.send_json(response)
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected")
+    finally:
+        connected_clients.discard(websocket)
+
+async def handle_command(cmd: dict):
+    method = cmd.get("method", "get").lower()
+    endpoint = cmd.get("endpoint", "/")
+    data = cmd.get("data")
+    url = f"{FRONTEND_URL}{endpoint}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            if method == "post":
+                resp = await client.post(url, json=data)
+            else:
+                resp = await client.get(url)
+            content_type = resp.headers.get("content-type", "")
+            if content_type.startswith("application/json"):
+                payload = resp.json()
+            else:
+                payload = resp.text
+            return {"status": "ok", "code": resp.status_code, "payload": payload}
+        except Exception as e:
+            logger.error(f"Error contacting frontend: {e}")
+            return {"status": "error", "message": str(e)}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8900)

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.100.0
+uvicorn[standard]>=0.22.0
+httpx>=0.24.0
+websockets>=10.0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+from mcp_server import main as mcp_main
+
+client = TestClient(mcp_main.app)
+
+def test_health():
+    r = client.get('/health')
+    assert r.status_code == 200
+    assert r.json()['status'] == 'ok'
+
+def test_handle_command_get(monkeypatch):
+    class FakeResp:
+        status_code = 200
+        headers = {"content-type":"application/json"}
+        def json(self):
+            return {"hello":"world"}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, url):
+            return FakeResp()
+        async def post(self, url, json=None):
+            return FakeResp()
+
+    monkeypatch.setattr(mcp_main.httpx, "AsyncClient", lambda *a, **kw: FakeClient())
+    res = asyncio.run(mcp_main.handle_command({"endpoint":"/"}))
+    assert res["payload"] == {"hello":"world"}


### PR DESCRIPTION
## Summary
- implement new `mcp_server` FastAPI application
- wire the server into docker-compose
- document MCP server in README
- add unit tests for MCP server

## Testing
- `pytest tests/test_mcp_server.py -q`
- `pytest -q` *(fails: numpy module mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6889e2523994833286b1a2acf8858d92