### PR TITLE
Allow uvicorn startup for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ cd /home/hafnium/aloha-lite/frontend
 python -m uvicorn main:app --host 0.0.0.0 --port 3000
 ```
 
+**MCP Server (Port 8900):**
+```bash
+cd /home/hafnium/aloha-lite/mcp_server
+python -m uvicorn main:app --host 0.0.0.0 --port 8900
+```
+
 **Access the System:**
 - **Web Interface**: http://localhost:3000 (Main color mixing and beaker analysis interface with SAM 2 integration)
 - **Robot Service API**: http://localhost:8000/docs (Direct robot control API)

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -58,6 +58,8 @@ async def handle_command(cmd: dict):
             logger.error(f"Error contacting frontend: {e}")
             return {"status": "error", "message": str(e)}
 
-if __name__ == "__main__":
+
+# Uvicorn entry point is ``mcp_server.main:app``
+if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8900)
+    uvicorn.run("mcp_server.main:app", host="0.0.0.0", port=8900)


### PR DESCRIPTION
## Summary
- expose MCP server for external uvicorn
- document how to start MCP server via uvicorn

## Testing
- `MODEL_ID=test PHOS_URL=http://phos REQUIRE_MODEL=true pytest tests/test_mcp_server.py tests/test_robot_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688acceecf148332bc30b2ee3234a5ea