### PR TITLE
Proxy frontend via MCP server

### DIFF
--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -2,7 +2,14 @@ import os
 import json
 import logging
 import httpx
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import (
+    FastAPI,
+    WebSocket,
+    WebSocketDisconnect,
+    Request,
+    Response,
+    HTTPException,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -13,9 +20,11 @@ app = FastAPI(title="MCP Server", description="Bridge for Anthropic Claude Deskt
 
 connected_clients = set()
 
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}
+
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
@@ -36,6 +45,7 @@ async def websocket_endpoint(websocket: WebSocket):
         logger.info("WebSocket disconnected")
     finally:
         connected_clients.discard(websocket)
+
 
 async def handle_command(cmd: dict):
     method = cmd.get("method", "get").lower()
@@ -59,7 +69,40 @@ async def handle_command(cmd: dict):
             return {"status": "error", "message": str(e)}
 
 
+@app.api_route(
+    "/{full_path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+)
+async def proxy_frontend(full_path: str, request: Request):
+    """Proxy arbitrary HTTP requests to the frontend service."""
+    if full_path == "ws":
+        raise HTTPException(status_code=404)
+
+    url = httpx.URL(FRONTEND_URL).join(full_path)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.request(
+                request.method,
+                str(url),
+                params=request.query_params,
+                content=await request.body(),
+                headers={
+                    k: v for k, v in request.headers.items() if k.lower() != "host"
+                },
+            )
+        except Exception as e:
+            logger.error(f"Error proxying to frontend: {e}")
+            raise HTTPException(status_code=502, detail="Error contacting frontend")
+
+    headers = {
+        k: v
+        for k, v in resp.headers.items()
+        if k.lower() not in {"content-length", "transfer-encoding", "connection"}
+    }
+    return Response(content=resp.content, status_code=resp.status_code, headers=headers)
+
+
 # Uvicorn entry point is ``mcp_server.main:app``
 if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
     import uvicorn
+
     uvicorn.run("mcp_server.main:app", host="0.0.0.0", port=8900)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys, os
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient
@@ -8,28 +9,56 @@ from mcp_server import main as mcp_main
 
 client = TestClient(mcp_main.app)
 
+
 def test_health():
-    r = client.get('/health')
+    r = client.get("/health")
     assert r.status_code == 200
-    assert r.json()['status'] == 'ok'
+    assert r.json()["status"] == "ok"
+
 
 def test_handle_command_get(monkeypatch):
     class FakeResp:
         status_code = 200
-        headers = {"content-type":"application/json"}
+        headers = {"content-type": "application/json"}
+
         def json(self):
-            return {"hello":"world"}
+            return {"hello": "world"}
 
     class FakeClient:
         async def __aenter__(self):
             return self
+
         async def __aexit__(self, exc_type, exc, tb):
             pass
+
         async def get(self, url):
             return FakeResp()
+
         async def post(self, url, json=None):
             return FakeResp()
 
     monkeypatch.setattr(mcp_main.httpx, "AsyncClient", lambda *a, **kw: FakeClient())
-    res = asyncio.run(mcp_main.handle_command({"endpoint":"/"}))
-    assert res["payload"] == {"hello":"world"}
+    res = asyncio.run(mcp_main.handle_command({"endpoint": "/"}))
+    assert res["payload"] == {"hello": "world"}
+
+
+def test_proxy_frontend(monkeypatch):
+    class FakeResp:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        content = b"<html>ok</html>"
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def request(self, method, url, params=None, content=None, headers=None):
+            return FakeResp()
+
+    monkeypatch.setattr(mcp_main.httpx, "AsyncClient", lambda *a, **kw: FakeClient())
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.text == "<html>ok</html>"


### PR DESCRIPTION
## Summary
- implement a proxy route in `mcp_server` so HTTP requests are forwarded to the frontend service
- expand tests to cover the new proxy route

## Testing
- `pytest tests/test_mcp_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688c5760275c83328c6153ae0bac4d29