### PR TITLE
feat: bridge MCP server to Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ python -m uvicorn main:app --host 0.0.0.0 --port 3000
 
 **MCP Server (Port 8900):**
 ```bash
+# Start Playwright MCP server (WebSocket JSON-RPC)
+uvx playwright-mcp --port 9010 &
+
+# Run the FastAPI bridge
 cd /home/hafnium/aloha-lite/mcp_server
-python -m uvicorn main:app --host 0.0.0.0 --port 8900
+uv run server.py
 ```
 
 **Access the System:**

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,31 +1,37 @@
-# Aloha-Lite MCP Server
+# Aloha-Lite MCP Bridge (Playwright)
 
-A lightweight bridge that exposes the Aloha-Lite frontend over the Model Context Protocol (MCP). It allows Anthropic Claude Desktop to control the robotics stack through simple HTTP and WebSocket commands.
+This service exposes a WebSocket bridge so Anthropic Claude Desktop can drive the
+Aloha-Lite demo through the **Playwright MCP server**.
 
 ## Features
 
-- 🔌 **WebSocket Command Channel** for real-time communication with Claude Desktop
-- 🌐 **HTTP Proxy** that forwards requests to the Aloha-Lite frontend
-- 💓 **Health Check** endpoint for monitoring
-- 🛠️ **Minimal Dependencies**: FastAPI, httpx, websockets, uvicorn
+- 🔌 **WebSocket JSON-RPC** – one message per Playwright tool call
+- 📡 **Live view streaming** at `/stream.mjpeg` (HTTP MJPEG) and `/stream_ws` (WebSocket PNG)
+- 💓 **Health check** at `/health`
 
 ## Quick Start
 
 ```bash
+# 1. Install Python deps
 uv sync
+
+# 2. Start the Playwright MCP server (defaults to ws://localhost:9010)
+uvx playwright-mcp --port 9010
+
+# 3. Run the bridge on port 8900
 cd mcp_server
-python -m uvicorn main:app --host 0.0.0.0 --port 8900
+uv run server.py
 ```
 
 ### Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `FRONTEND_URL` | URL of the Aloha-Lite frontend service | `http://frontend` |
+| Variable            | Description                                             | Default              |
+|---------------------|---------------------------------------------------------|----------------------|
+| `PLAYWRIGHT_MCP_WS` | WebSocket URL where the Playwright MCP server is running | `ws://localhost:9010` |
 
 ## Claude Desktop Integration
 
-Add the MCP server to your `claude_desktop_config.json`:
+Add the server to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -44,22 +50,5 @@ Add the MCP server to your `claude_desktop_config.json`:
 ```
 
 1. Ensure dependencies are installed with `uv sync`.
-2. Update the path above to the location of your `aloha-lite` checkout.
+2. Start the Playwright MCP server separately (step 2 above) or set `PLAYWRIGHT_MCP_WS`.
 3. Restart Claude Desktop to load the new tools.
-
-## API Endpoints
-
-### `GET /health`
-Simple health check returning `{ "status": "ok" }`.
-
-### `WS /ws`
-Bidirectional channel for sending commands to the frontend.
-
-### `/{path}` (HTTP Proxy)
-Proxies arbitrary HTTP requests to `FRONTEND_URL`.
-
-## Architecture
-
-```
-Claude Desktop → MCP Server → Aloha-Lite Frontend → Robot Service → Vision Bridge
-```

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,108 +1,129 @@
+"""
+Playwright-backed MCP bridge for Claude Desktop
+
+• Listens on /ws (JSON-RPC over WebSocket) for Claude
+• Relays each call to a local Playwright MCP server (JSON-RPC over WebSocket)
+• Provides a simple /health endpoint for probes
+• Optional: live screenshot streaming over HTTP MJPEG and WebSocket
+"""
+
 import os
 import json
+import uuid
 import logging
-import httpx
-from fastapi import (
-    FastAPI,
-    WebSocket,
-    WebSocketDisconnect,
-    Request,
-    Response,
-    HTTPException,
-)
+import asyncio
+import base64
+import io
+import websockets
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from starlette.responses import StreamingResponse
+from PIL import Image
 
+# ───────────────────────────────────────────────────────────────────────────────
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("mcp_bridge")
 
-FRONTEND_URL = os.getenv("FRONTEND_URL", "http://frontend")
+# Where the Playwright MCP server is listening (e.g. `playwright-mcp --port 9010`)
+PLAYWRIGHT_MCP_WS = os.getenv("PLAYWRIGHT_MCP_WS", "ws://localhost:9010")
 
-app = FastAPI(title="MCP Server", description="Bridge for Anthropic Claude Desktop")
+app = FastAPI(title="MCP Bridge (Playwright)", description="For Anthropic Claude Desktop")
+connected_clients: set[WebSocket] = set()
 
-connected_clients = set()
+# ────────────────────────────── Utilities ──────────────────────────────────────
+async def call_playwright(method: str, params: dict | None = None) -> dict:
+    """Forward a single JSON-RPC 2.0 request to the Playwright MCP server."""
+    request_id = str(uuid.uuid4())
+    payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+
+    async with websockets.connect(PLAYWRIGHT_MCP_WS) as ws:
+        await ws.send(json.dumps(payload))
+        raw = await ws.recv()
+
+    response = json.loads(raw)
+    if "error" in response:
+        raise RuntimeError(response["error"])
+    return response.get("result")
 
 
+async def grab_png() -> bytes:
+    """Ask Playwright MCP for a full-page PNG screenshot."""
+    result = await call_playwright("page.screenshot", {"fullPage": True, "type": "png"})
+    return base64.b64decode(result["data"])
+
+BOUNDARY = b"--frame"
+
+async def mjpeg_frame_generator():
+    while True:
+        try:
+            png_bytes = await grab_png()
+            jpg_bytes_io = io.BytesIO()
+            Image.open(io.BytesIO(png_bytes)).save(jpg_bytes_io, format="JPEG", quality=75)
+            payload = (
+                BOUNDARY + b"\r\n"
+                + b"Content-Type: image/jpeg\r\n\r\n"
+                + jpg_bytes_io.getvalue() + b"\r\n"
+            )
+            yield payload
+        except Exception as exc:
+            logger.error("Stream error: %s", exc)
+            await asyncio.sleep(1.0)
+        await asyncio.sleep(0.5)
+
+# ────────────────────────────── Health probe ───────────────────────────────────
 @app.get("/health")
 async def health():
     return {"status": "ok"}
 
+# ───────────────────────────── Streaming routes ───────────────────────────────
+@app.get("/stream.mjpeg")
+async def stream_mjpeg():
+    headers = {
+        "Age": "0",
+        "Cache-Control": "no-cache, private",
+        "Pragma": "no-cache",
+        "Content-Type": "multipart/x-mixed-replace; boundary=frame",
+    }
+    return StreamingResponse(mjpeg_frame_generator(), headers=headers)
 
+@app.websocket("/stream_ws")
+async def stream_ws(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            try:
+                png_bytes = await grab_png()
+                b64 = base64.b64encode(png_bytes).decode()
+                await websocket.send_json({"png_base64": b64})
+            except Exception as exc:
+                await websocket.send_json({"error": str(exc)})
+            await asyncio.sleep(0.5)
+    except WebSocketDisconnect:
+        pass
+
+# ───────────────────────────── WebSocket API ───────────────────────────────────
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
+    """Relay JSON-RPC commands from Claude to Playwright MCP."""
     await websocket.accept()
     connected_clients.add(websocket)
     await websocket.send_json({"status": "connected"})
+
     try:
         while True:
-            msg = await websocket.receive_text()
+            text = await websocket.receive_text()
             try:
-                cmd = json.loads(msg)
-            except json.JSONDecodeError:
-                await websocket.send_json({"error": "invalid json"})
-                continue
-            response = await handle_command(cmd)
-            await websocket.send_json(response)
+                cmd = json.loads(text)
+                result = await call_playwright(cmd["method"], cmd.get("params"))
+                await websocket.send_json({"status": "ok", "result": result})
+            except Exception as exc:
+                logger.exception("MCP call failed")
+                await websocket.send_json({"status": "error", "message": str(exc)})
     except WebSocketDisconnect:
         logger.info("WebSocket disconnected")
     finally:
         connected_clients.discard(websocket)
 
-
-async def handle_command(cmd: dict):
-    method = cmd.get("method", "get").lower()
-    endpoint = cmd.get("endpoint", "/")
-    data = cmd.get("data")
-    url = f"{FRONTEND_URL}{endpoint}"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        try:
-            if method == "post":
-                resp = await client.post(url, json=data)
-            else:
-                resp = await client.get(url)
-            content_type = resp.headers.get("content-type", "")
-            if content_type.startswith("application/json"):
-                payload = resp.json()
-            else:
-                payload = resp.text
-            return {"status": "ok", "code": resp.status_code, "payload": payload}
-        except Exception as e:
-            logger.error(f"Error contacting frontend: {e}")
-            return {"status": "error", "message": str(e)}
-
-
-@app.api_route(
-    "/{full_path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
-)
-async def proxy_frontend(full_path: str, request: Request):
-    """Proxy arbitrary HTTP requests to the frontend service."""
-    if full_path == "ws":
-        raise HTTPException(status_code=404)
-
-    url = httpx.URL(FRONTEND_URL).join(full_path)
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        try:
-            resp = await client.request(
-                request.method,
-                str(url),
-                params=request.query_params,
-                content=await request.body(),
-                headers={
-                    k: v for k, v in request.headers.items() if k.lower() != "host"
-                },
-            )
-        except Exception as e:
-            logger.error(f"Error proxying to frontend: {e}")
-            raise HTTPException(status_code=502, detail="Error contacting frontend")
-
-    headers = {
-        k: v
-        for k, v in resp.headers.items()
-        if k.lower() not in {"content-length", "transfer-encoding", "connection"}
-    }
-    return Response(content=resp.content, status_code=resp.status_code, headers=headers)
-
-
-# Uvicorn entry point is ``mcp_server.main:app``
-if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
+# ──────────────────────────── Local launcher (dev only) ────────────────────────
+if __name__ == "__main__":  # pragma: no cover
     import uvicorn
-
     uvicorn.run("mcp_server.main:app", host="0.0.0.0", port=8900)

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.100.0
 uvicorn[standard]>=0.22.0
-httpx>=0.24.0
 websockets>=10.0
+pillow>=10.0

--- a/mcp_server/system_prompt.md
+++ b/mcp_server/system_prompt.md
@@ -19,7 +19,7 @@ The robot arms are rule-driven today (no physics-AI control), but you still demo
 | Channel | Purpose | Format |
 |---------|---------|--------|
 | **Chat** | Talk to participants (Japanese only) | Plain Japanese sentences; short, clear, friendly |
-| **MCP WebSocket** | Control the demo cell | **Strict JSON** messages. Example:<br>```json<br>{"method":"post","endpoint":"/robot/dispense","data":{"color":"red","duration":3.0}}<br>```<br>Send one command per message and wait for the returned JSON response (`status_code`, `payload`) before issuing the next |
+| **MCP WebSocket** | Send JSON-RPC 2.0 for Playwright tools | One call per message. Example:<br>```json<br>{"method":"page.fill","params":{"selector":"#r","value":"255"}}<br>``` |
 
 ---
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,7 @@
+import os
+import json
 import asyncio
-import sys, os
+import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -11,54 +13,26 @@ client = TestClient(mcp_main.app)
 
 
 def test_health():
-    r = client.get("/health")
-    assert r.status_code == 200
-    assert r.json()["status"] == "ok"
-
-
-def test_handle_command_get(monkeypatch):
-    class FakeResp:
-        status_code = 200
-        headers = {"content-type": "application/json"}
-
-        def json(self):
-            return {"hello": "world"}
-
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def get(self, url):
-            return FakeResp()
-
-        async def post(self, url, json=None):
-            return FakeResp()
-
-    monkeypatch.setattr(mcp_main.httpx, "AsyncClient", lambda *a, **kw: FakeClient())
-    res = asyncio.run(mcp_main.handle_command({"endpoint": "/"}))
-    assert res["payload"] == {"hello": "world"}
-
-
-def test_proxy_frontend(monkeypatch):
-    class FakeResp:
-        status_code = 200
-        headers = {"content-type": "text/html"}
-        content = b"<html>ok</html>"
-
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def request(self, method, url, params=None, content=None, headers=None):
-            return FakeResp()
-
-    monkeypatch.setattr(mcp_main.httpx, "AsyncClient", lambda *a, **kw: FakeClient())
-    resp = client.get("/")
+    resp = client.get("/health")
     assert resp.status_code == 200
-    assert resp.text == "<html>ok</html>"
+    assert resp.json()["status"] == "ok"
+
+
+def test_call_playwright(monkeypatch):
+    class DummyWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def send(self, msg):
+            self.sent = json.loads(msg)
+
+        async def recv(self):
+            return json.dumps({"result": {"echo": self.sent}})
+
+    monkeypatch.setattr(mcp_main.websockets, "connect", lambda url: DummyWS())
+    res = asyncio.run(mcp_main.call_playwright("page.test", {"foo": "bar"}))
+    assert res["echo"]["method"] == "page.test"
+    assert res["echo"]["params"] == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- replace ad-hoc MCP HTTP proxy with Playwright-based JSON-RPC bridge
- add optional live screenshot streaming via MJPEG and WebSocket
- document Playwright setup with uv and update system prompt

## Testing
- `pytest tests/test_mcp_server.py -q`
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688ebdca1b5c8332b41c22e236394e42